### PR TITLE
Trim and filter prerequisite IDs for Cytoscape edges

### DIFF
--- a/data.py
+++ b/data.py
@@ -42,7 +42,11 @@ def create_cytoscape_elements(dataframe):
         # --- 2. إنشاء الروابط (Edges) ---
         if row['prerequisite_id'] != 'nan':
             # التعامل مع حالة وجود أكثر من متطلب واحد
-            prerequisites = row['prerequisite_id'].split(',')
+            prerequisites = [
+                prereq.strip()
+                for prereq in row['prerequisite_id'].split(',')
+                if prereq.strip()
+            ]
             for prereq in prerequisites:
                 edges.append({
                     'data': {


### PR DESCRIPTION
### Motivation
- Ensure edge `source` values exactly match node `id` by trimming whitespace and skipping empty prerequisites when building Cytoscape elements.

### Description
- In `data.py` `create_cytoscape_elements` replace the simple `split(',')` usage with a list comprehension that calls `strip()` and filters out empty strings so edges use trimmed `prereq` values.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d98b544483249fcdc9d3a2d312b6)