### PR TITLE
Derive cytoscape root nodes from dataset (courses without prerequisites)

### DIFF
--- a/callbacks.py
+++ b/callbacks.py
@@ -142,8 +142,11 @@ def clear_selections(n_clicks):
     Input('layout-selector', 'value')
 )
 def update_cytoscape_layout(layout_name):
-    # القيم الثابتة للجذور، يمكن جعلها ديناميكية مستقبلاً
-    root_nodes_selector = '[id = "ITGS211"], [id = "ITGS223"], [id = "ITGS215"], [id = "ITGS224"], [id = "ITGS226"], [id = "ITGS228"]'
+    root_course_ids = df.loc[
+        df['prerequisite_id'].isna() | (df['prerequisite_id'] == ''),
+        'course_id'
+    ].tolist()
+    root_nodes_selector = ', '.join([f'[id = "{course_id}"]' for course_id in root_course_ids])
 
     if layout_name == 'dagre':
         return {


### PR DESCRIPTION
### Motivation
- Replace hard-coded cytoscape root node IDs with a dynamic selector computed from the dataset so layouts adapt to the CSV data instead of fixed course IDs.  
- Identify root courses as those with empty or NaN `prerequisite_id` values.

### Description
- Updated `update_cytoscape_layout` in `callbacks.py` to compute `root_course_ids` using `df.loc[df['prerequisite_id'].isna() | (df['prerequisite_id'] == ''), 'course_id'].tolist()` and to build `root_nodes_selector` with `', '.join([f'[id = "{course_id}"]' for course_id in root_course_ids])`.  
- Kept the existing layout return values for `'dagre'`, `'breadthfirst'`, and other layouts unchanged; only the `roots` value is now dynamic.  
- Change is localized to `callbacks.py` and affects how the `cytoscape-graph` layout roots are provided.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967d9a25a148324b232553907f429a3)